### PR TITLE
kvm_compat: add missing KVM constants

### DIFF
--- a/include/kvm_compat.h
+++ b/include/kvm_compat.h
@@ -21,4 +21,12 @@
 # define KVM_ENOMEM ENOMEM
 #endif
 
+#ifndef KVM_EINVAL
+# define KVM_EINVAL EINVAL
+#endif
+
+#ifndef KVM_EOPNOTSUPP
+# define KVM_EOPNOTSUPP 95
+#endif
+
 #endif


### PR DESCRIPTION
It should fix [this failure](https://github.com/Wenzel/libkvmi/runs/891313316?check_suite_focus=true#step:5:11)