### PR TITLE
Support for singlestep events

### DIFF
--- a/include/libkvmi.h
+++ b/include/libkvmi.h
@@ -40,6 +40,7 @@ struct kvmi_dom_event {
 			struct kvmi_event_trap       trap;
 			struct kvmi_event_descriptor desc;
 			struct kvmi_event_cpuid      cpuid;
+			struct kvmi_event_singlestep ss;
 		};
 	} event;
 	unsigned char buf[KVMI_MSG_SIZE];

--- a/include/linux/x86_64/asm/kvmi.h
+++ b/include/linux/x86_64/asm/kvmi.h
@@ -143,4 +143,9 @@ struct kvmi_event_cpuid {
 	__u32 padding2;
 };
 
+struct kvmi_event_singlestep {
+	__u8 failed;
+	__u8 padding[7];
+};
+
 #endif /* _UAPI_ASM_X86_KVMI_H */

--- a/src/kvmi.c
+++ b/src/kvmi.c
@@ -1246,7 +1246,7 @@ static int expected_event_data_size( size_t event_id, size_t *size )
                 [KVMI_EVENT_TRAP]        = sizeof( struct kvmi_event_trap ),
                 [KVMI_EVENT_UNHOOK]      = 1,
                 [KVMI_EVENT_XSETBV]      = 1,
-                [KVMI_EVENT_SINGLESTEP]  = 1,
+                [KVMI_EVENT_SINGLESTEP]  = sizeof( struct kvmi_event_singlestep ),
                 [KVMI_EVENT_CPUID]       = sizeof( struct kvmi_event_cpuid ),
 	};
 


### PR DESCRIPTION
Exposes the failed state of singlestep events, which will be needed in libvmi to harmonize the behavior across hypervisors