### PR TITLE
libkvmi: guest page mapping from host

### DIFF
--- a/include/linux/kvmi.h
+++ b/include/linux/kvmi.h
@@ -53,6 +53,7 @@ enum {
 	KVMI_CONTROL_EPT_VIEW      = 36,
 	KVMI_VCPU_GET_XCR          = 37,
 	KVMI_VCPU_SET_XSAVE        = 38,
+	KVMI_QUERY_PHYSICAL        = 39,
 	KVMI_VCPU_CHANGE_GFN       = 60,
 
 	KVMI_VCPU_CONTROL_SINGLESTEP = 63,
@@ -199,6 +200,15 @@ struct kvmi_write_physical {
 	__u64 gpa;
 	__u64 size;
 	__u8  data[0];
+};
+
+struct kvmi_query_physical {
+	__u64 gfn;
+};
+
+struct kvmi_query_physical_reply {
+	__u64 gfn;
+	__u64 size;
 };
 
 struct kvmi_vcpu_hdr {

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -3,5 +3,5 @@ AM_CFLAGS = -I$(top_srcdir)/include -I$(top_srcdir)/include/linux/$(ARCH)
 lib_LTLIBRARIES = libkvmi.la
 
 libkvmi_la_SOURCES = kvmi.c
-libkvmi_la_LDFLAGS = -pthread -version-number 1:1 \
+libkvmi_la_LDFLAGS = -luuid -pthread -version-number 1:1 \
 	-Wl,--version-script,$(srcdir)/version.ld


### PR DESCRIPTION
Implements transparent guest page mapping for introspection applications on the host.

See https://github.com/KVM-VMI/kvm/pull/56.